### PR TITLE
Fixes #6. Use Windows line break instead of System.lineSeparator()

### DIFF
--- a/src/test/java/com/quirk/csv/test/InheritanceTest.java
+++ b/src/test/java/com/quirk/csv/test/InheritanceTest.java
@@ -13,10 +13,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class InheritanceTest {
+	private final static String LINE_SEPARATOR = "\r\n";
 
 	@Test
 	public void orderTest() throws IOException {
-		final String str = "1,sts"+System.lineSeparator();
+		final String str = "1,sts"+LINE_SEPARATOR;
 		ChildO1 o = new ChildO1();
 		o.a = 1;
 		o.b = "sts";
@@ -31,7 +32,7 @@ public class InheritanceTest {
 
 	@Test
 	public void namedTest() throws IOException {
-		final String str = "a,b" + System.lineSeparator() + "1,sts"+System.lineSeparator();
+		final String str = "a,b" + LINE_SEPARATOR + "1,sts"+LINE_SEPARATOR;
 		ChildN1 o = new ChildN1();
 		o.a = 1;
 		o.b = "sts";

--- a/src/test/java/com/quirk/csv/test/NamedTest.java
+++ b/src/test/java/com/quirk/csv/test/NamedTest.java
@@ -17,12 +17,13 @@ import static org.junit.Assert.assertTrue;
 
 public class NamedTest {
 	
+	private final static String LINE_SEPARATOR = "\r\n";
 
 	@Test()
 	public void NumberFormatExTest() throws IOException {
 
 		CSVProcessor<O1> p = new CSVProcessor<>(O1.class);
-		String csv = "a,b,c" + System.lineSeparator() + "a,0,1"+System.lineSeparator();
+		String csv = "a,b,c" + LINE_SEPARATOR + "a,0,1"+LINE_SEPARATOR;
 		List<O1> o1s = p.parse(new StringReader(csv));
 		O1 o1 = new O1();
 		o1.s = "a";
@@ -39,14 +40,14 @@ public class NamedTest {
 	public void readUninstantiableExTest() throws IOException {
 
 		CSVProcessor<O2> p = new CSVProcessor<>(O2.class);
-		List<O2> o2 = p.parse(new StringReader("a,b,c" + System.lineSeparator() + "a,j,u"));
+		List<O2> o2 = p.parse(new StringReader("a,b,c" + LINE_SEPARATOR + "a,j,u"));
 
 	}
 	@Test(expected = NamedParserException.class)
 	public void readNamedParserExceptionTest() throws IOException {
 
 		CSVProcessor<O3> p = new CSVProcessor<>(O3.class);
-		 p.parse(new StringReader("a,b,c" + System.lineSeparator() + "a,j,u"));
+		 p.parse(new StringReader("a,b,c" + LINE_SEPARATOR + "a,j,u"));
 	}
 
 

--- a/src/test/java/com/quirk/csv/test/OrderTest.java
+++ b/src/test/java/com/quirk/csv/test/OrderTest.java
@@ -16,10 +16,12 @@ import static org.junit.Assert.assertTrue;
 
 public class OrderTest {
 
+	private final static String LINE_SEPARATOR = "\r\n";
+
 	@Test()
 	public void positiveOrderTest() throws IOException {
 		CSVProcessor<O1> p = new CSVProcessor<>(O1.class);
-		String csv = "a,0,NAMED,d,0"+System.lineSeparator();
+		String csv = "a,0,NAMED,d,0"+LINE_SEPARATOR;
 		List<O1> o1s = p.parse(new StringReader(csv));
 		O1 o1 = new O1();
 		o1.s = "a";


### PR DESCRIPTION
code must be tested on Windows et Unix systems