### PR TITLE
Replace clazz.newInstance() with clazz.getDeclaredConstructor().newInstance()

### DIFF
--- a/src/main/java/com/quirk/csv/processor/AbstractCSVReadProcessor.java
+++ b/src/main/java/com/quirk/csv/processor/AbstractCSVReadProcessor.java
@@ -128,11 +128,11 @@ public abstract class AbstractCSVReadProcessor<T> {
         ReadWrapper wrap = this.wrapperInstantiated.get(wrapper);
         if (wrap == null) {
             try {
-                wrap = wrapper.newInstance();
+                wrap = wrapper.getDeclaredConstructor().newInstance();
                 this.wrapperInstantiated.put((Class<ReadWrapper>) wrapper, wrap);
 
                 return wrap;
-            } catch (InstantiationException | IllegalAccessException e) {
+            } catch (ReflectiveOperationException e) {
                 LOGGER.log(Level.SEVERE, "Make sure your ReadWrapper class has a public no args constructor", e);
                 throw new WrapperInstantiationException("ReadWrapper class does not have public no args constructor");
             }

--- a/src/main/java/com/quirk/csv/processor/AbstractCSVWriteProcessor.java
+++ b/src/main/java/com/quirk/csv/processor/AbstractCSVWriteProcessor.java
@@ -130,11 +130,11 @@ public abstract class AbstractCSVWriteProcessor<T> {
         WriteWrapper wrap = this.wrapperInstantiated.get(wrapper);
         if (wrap == null) {
             try {
-                wrap = wrapper.newInstance();
+                wrap = wrapper.getDeclaredConstructor().newInstance();
                 this.wrapperInstantiated.put((Class<WriteWrapper>) wrapper, wrap);
 
                 return wrap;
-            } catch (InstantiationException | IllegalAccessException e) {
+            } catch (ReflectiveOperationException e) {
                 LOGGER.log(Level.SEVERE, "Make sure your WriteWrapper class has a public no args constructor", e);
                 throw new WrapperInstantiationException("WriteWrapper class does not have public no args constructor");
             }

--- a/src/main/java/com/quirk/csv/processor/CSVNamedReadProcessor.java
+++ b/src/main/java/com/quirk/csv/processor/CSVNamedReadProcessor.java
@@ -49,7 +49,7 @@ class CSVNamedReadProcessor<T> extends AbstractCSVReadProcessor<T> {
             while(iterator.hasNext()){
                 consumer.accept(getCSVRecord(iterator,map));
             }
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (ReflectiveOperationException e) {
             LOGGER.log(Level.SEVERE,
                     "Could not create object. Check to make sure the you have a visible default constructor", e);
             throw new UninstantiableException(
@@ -57,10 +57,10 @@ class CSVNamedReadProcessor<T> extends AbstractCSVReadProcessor<T> {
         }
     }
 
-    private T getCSVRecord(Iterator<CSVRecord> iterator, Map<String, CSVReadAnnotationManager> map) throws InstantiationException, IllegalAccessException {
+    private T getCSVRecord(Iterator<CSVRecord> iterator, Map<String, CSVReadAnnotationManager> map) throws ReflectiveOperationException {
         CSVRecord record = iterator.next();
 
-        Object obj = parsedClazz.newInstance();
+        T obj = parsedClazz.getDeclaredConstructor().newInstance();
         for (Entry<String, CSVReadAnnotationManager> entry : map.entrySet()) {
             CSVReadAnnotationManager cm = entry.getValue();
             String header = entry.getKey();
@@ -71,6 +71,6 @@ class CSVNamedReadProcessor<T> extends AbstractCSVReadProcessor<T> {
             }
 
         }
-        return(T) obj;
+        return obj;
     }
 }

--- a/src/main/java/com/quirk/csv/processor/CSVOrderReadProcessor.java
+++ b/src/main/java/com/quirk/csv/processor/CSVOrderReadProcessor.java
@@ -52,7 +52,7 @@ class CSVOrderReadProcessor<T> extends AbstractCSVReadProcessor<T> {
                 consumer.accept(getCSVRecord(iterator, map));
             }
 
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (ReflectiveOperationException e) {
             LOGGER.log(Level.SEVERE,
                     "Could not create object. Check to make sure the you have a visible default constructor", e);
             throw new UninstantiableException(
@@ -60,9 +60,9 @@ class CSVOrderReadProcessor<T> extends AbstractCSVReadProcessor<T> {
         }
     }
 
-    private T getCSVRecord(Iterator<CSVRecord> iterator, Map<Integer, CSVReadAnnotationManager> map) throws InstantiationException, IllegalAccessException {
+    private T getCSVRecord(Iterator<CSVRecord> iterator, Map<Integer, CSVReadAnnotationManager> map) throws ReflectiveOperationException {
         CSVRecord record = iterator.next();
-        Object obj = parsedClazz.newInstance();
+        T obj = parsedClazz.getDeclaredConstructor().newInstance();
         for (Entry<Integer, CSVReadAnnotationManager> entry : map.entrySet()) {
             CSVReadAnnotationManager cm = entry.getValue();
             int order = entry.getKey();
@@ -78,6 +78,6 @@ class CSVOrderReadProcessor<T> extends AbstractCSVReadProcessor<T> {
             }
 
         }
-        return (T) obj;
+        return obj;
     }
 }


### PR DESCRIPTION
newInstance should not be used. It becomes deprecated since java 9